### PR TITLE
ci: add GitHub Actions pipeline for Maven multi-module build

### DIFF
--- a/github/workflows/ci.yaml
+++ b/github/workflows/ci.yaml
@@ -1,0 +1,28 @@
+name: CI Pipeline
+
+on:
+    push:
+        branches:
+            - master
+            - 'feature/*'
+    pull_request:
+        branches:
+            - master
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Set up JDK 24
+              uses: actions/setup-java@v4
+              with:
+                  java-version: '24'
+                  distribution: 'temurin'
+                  cache: maven
+
+            - name: Build with Maven
+              run: mvn clean install


### PR DESCRIPTION
- Trigger on pushes to master and feature/* branches
- Trigger on pull requests targeting master
- Run `mvn clean install` at project root to build all modules